### PR TITLE
Addition of Picomotor 8742

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,8 @@ Authors
 * David Bresteau (david.bresteau@cea.fr)
 * Sébastien Quistrebert (sebastien.quistrebert@ens-paris-saclay.fr)
 * Bastien Bégon (bastien.begon@crpp.cnrs.fr)
+* Elias Sfeir
+* Aurore Finco (aurore.finco@umontpellier.fr)
 
 Instruments
 ===========
@@ -35,6 +37,7 @@ Actuators
 * **AgilisSerial**: for controllers AG-UC8 and AG-UC2 tested with motorized mounts AG-M100N (no encoder)
 * **XPS-Q8**: 8-axis Universal Motion Controller/Driver, ethernet
 * **SMC100**: Single axis motion controller
+* **Picomotor8742**: 4-axis open-loop motion controller
 
 Installation notes
 ==================
@@ -68,5 +71,11 @@ Installing `Newport SMC100 software <https://www.newport.com/f/smc100-single-axi
 Operating System: Windows 11
 
 PyMoDAQ version: 4.3.0 running in a conda environment with Python 3.11.9
+
+Picomotor 8742
+++++++++++++++
+
+This plugin uses the pylablib driver.
+Tested on Windows 10 with pymodaq >= 4.4.0 in a conda environment with Python 3.8
 
 

--- a/src/pymodaq_plugins_newport/daq_move_plugins/daq_move_Newport_Picomotor8742.py
+++ b/src/pymodaq_plugins_newport/daq_move_plugins/daq_move_Newport_Picomotor8742.py
@@ -1,8 +1,10 @@
-from pymodaq.control_modules.move_utility_classes import DAQ_Move_base, comon_parameters_fun, main  # common set of parameters for all actuators
+from typing import Union, List, Dict
+
+from pymodaq.control_modules.move_utility_classes import DAQ_Move_base,\
+    comon_parameters_fun, main, DataActuatorType, DataActuator  # common set of parameters for all actuators
 from pymodaq.utils.daq_utils import ThreadCommand # object used to send info back to the main thread
 from pymodaq.utils.parameter import Parameter
 from pylablib.devices import Newport
-
 
 
 class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
@@ -14,18 +16,25 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
         The particular object that allow the communication with the hardware, from pylablib
 
     """
-    _controller_units = ''
+    _controller_units: Union[str, List[str]] = ''
     is_multiaxes = True
-    axes_names = {'1': 1, '2': 2, '3': 3, '4': 4}
-    _epsilon = 10.0
+    axes_names: Union[List[str], Dict[str, int]] = {'1': 1, '2': 2, '3': 3, '4': 4}
+    _epsilon: Union[float, List[float]] = 10.0
+    data_actuator_type = DataActuatorType.DataActuator
+    
     params = [
               {'title': 'IP address:', 'name': 'ip', 'type': 'str','value': "192.168.0.109"},
               {'title': 'Axis parameters: ', 'name': 'axis_p','type': 'group','children':[
-                  {'title': 'Velocity (steps/s): ', 'name': 'speed_axis','type': 'int','value':0,'min':1,'max':2e3 },
-                  {'title': 'Acceleration (steps/s^2): ', 'name': 'acc_axis', 'type': 'int','value':0,'min':1,'max':2e5},
-                  {'title': 'Type: ', 'name': 'motor', 'type':'str','value':'None'},]}] + comon_parameters_fun(is_multiaxes, axes_names, epsilon=_epsilon)
-    # _epsilon is the initial default value for the epsilon parameter allowing pymodaq to know if the controller reached
-    # the target value. It is the developer responsibility to put here a meaningful value
+                  {'title': 'Velocity (steps/s): ', 'name': 'speed_axis','type': 'int',
+                   'value':0,'min':1,'max':2e3},
+                  {'title': 'Acceleration (steps/s^2): ', 'name': 'acc_axis', 'type': 'int',
+                   'value':0,'min':1,'max':2e5},
+                  {'title': 'Type: ', 'name': 'motor', 'type':'str','value':'None'},]}] + \
+                  comon_parameters_fun(is_multiaxes, axes_names, epsilon=_epsilon)
+
+    
+    def ini_attributes(self):
+        self.controller: Newport.Picomotor8742 = None
 
     def get_actuator_value(self):
         """Get the current value from the hardware with scaling conversion.
@@ -35,12 +44,13 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
         float: The position obtained after scaling conversion.
         """
         axis = self.axis_value
-        pos = self.controller.get_position(axis=axis)
+        pos = DataActuator(data=self.controller.get_position(axis=axis))
+        pos = self.get_position_with_scaling(pos)
         return pos
 
     def close(self):
         """Terminate the communication """
-        self.controller.close()  # when writing your own plugin replace this line
+        self.controller.close()  
 
     def commit_settings(self, param: Parameter):
         """Apply the consequences of a change of value in the detector settings
@@ -51,8 +61,9 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
             A given parameter (within detector_settings) whose value has been changed by the user
         """
         if param.name() == 'speed_axis' or param.name() == 'acc_axis':
-            self.controller.setup_velocity(axis=self.axis_value, speed=self.settings.child('axis_p','speed_axis').value(),
-                                           accel=self.settings.child('axis_p','acc_axis').value() )
+            self.controller.setup_velocity(axis=self.axis_value,
+                                           speed=self.settings['axis_p','speed_axis'],
+                                           accel=self.settings['axis_p','acc_axis'])
         else:
             pass
 
@@ -70,7 +81,6 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
         initialized: bool
             False if initialization failed otherwise True
         """
-
         self.controller = self.ini_stage_init(slave_controller=controller)
 
         if self.is_master:
@@ -86,16 +96,15 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
         if initialized:
             motor_types = self.controller.autodetect_motors()
             axis = self.axis_value
-            self.settings.child('axis_p','motor').setValue(motor_types[axis-1])
+            self.settings['axis_p','motor'] = motor_types[axis-1]
            
             parameters_velocity = self.controller.get_velocity_parameters()
-            self.settings.child('axis_p','speed_axis').setValue(parameters_velocity[axis][0])
-            self.settings.child('axis_p','acc_axis').setValue(parameters_velocity[axis][1])
-
-
-        return info, initialized 
-
-    def move_abs(self, value):
+            self.settings['axis_p','speed_axis'] = parameters_velocity[axis-1][0]
+            self.settings['axis_p','acc_axis'] = parameters_velocity[axis-1][1]
+            
+        return info, initialized
+    
+    def move_abs(self, value: DataActuator):
         """ Move the actuator to the absolute target defined by value
 
         Parameters
@@ -105,13 +114,13 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
 
         value = self.check_bound(value)  #if user checked bounds, the defined bounds are applied here
         self.target_value = value
-        value = self.set_position_with_scaling(value)  # apply scaling if the user specified one*
+        value = self.set_position_with_scaling(value)  # apply scaling if the user specified one
 
-        self.controller.move_to(self.axis_value, value)  # when writing your own plugin replace this line
-        self.emit_status(ThreadCommand('Update_Status', ['The actuator is moved {} steps'.format(value)]))
+        self.controller.move_to(self.axis_value, value.value())  
+        self.emit_status(ThreadCommand('Update_Status',
+                                       [f'The actuator is moved {value.value()} steps.']))
 
-
-    def move_rel(self, value):
+    def move_rel(self, value: DataActuator):
         """ Move the actuator to the relative target actuator value defined by value
 
         Parameters
@@ -122,19 +131,18 @@ class DAQ_Move_Newport_Picomotor8742(DAQ_Move_base):
         self.target_value = value + self.current_position
         value = self.set_position_relative_with_scaling(value)
 
-        self.controller.move_by(self.axis_value, steps=value)  # when writing your own plugin replace this line
-        self.emit_status(ThreadCommand('Update_Status', ['The actuator is moved according to its current position of {} steps'.format(value)]))
-
+        self.controller.move_by(self.axis_value, steps=value.value()) 
+        self.emit_status(ThreadCommand('Update_Status',
+                    [f'The actuator is moved according to its current position of {value.value()} steps.']))
 
     def move_home(self):
         """Do nothing"""
         pass
         
-        
     def stop_motion(self):
       """Stop the actuator and emits move_done signal"""
-      self.controller.stop(axis=self.axis_value)  # when writing your own plugin replace this line
-      self.emit_status(ThreadCommand('Update_Status', ['the motion of the actuator is stopped']))
+      self.controller.stop(axis=self.axis_value)
+      self.emit_status(ThreadCommand('Update_Status', ['The motion of the actuator is stopped.']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We propose a new daq_move for the Newport Picomotor 8742 controller, using the pylablib driver. 
We tested it in our lab with pymodaq 4.4.0.